### PR TITLE
feat(option): allow closing edgy when all windows are hidden

### DIFF
--- a/lua/edgy/config.lua
+++ b/lua/edgy/config.lua
@@ -38,6 +38,8 @@ local defaults = {
   },
   -- enable this to exit Neovim when only edgy windows are left
   exit_when_last = false,
+  -- close edgy when all windows are hidden instead of opening one of them
+  close_when_all_hidden = false,
   -- global window options for edgebar windows
   ---@type vim.wo
   wo = {

--- a/lua/edgy/edgebar.lua
+++ b/lua/edgy/edgebar.lua
@@ -98,10 +98,15 @@ function M:on_hide(win)
       end
     end
   end
+
   if visible > 0 then
     return
   end
   if #real == 0 then
+    return self:close()
+  end
+
+  if visible == 0 and require("edgy.config").close_when_all_hidden then
     return self:close()
   end
 


### PR DESCRIPTION
Love this plugin, but not a huge fan of the way hidden (collapsed) windows will reopen if all windows in their section are closed. This PR adds an option that closes an edgebar / edgy window entirely when all of its windows are hidden.