### PR TITLE
feat: allow configuring window size with functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ vim.opt.splitkeep = "screen"
   right = {}, ---@type (Edgy.View.Opts|string)[]
   top = {}, ---@type (Edgy.View.Opts|string)[]
 
-  ---@type table<Edgy.Pos, {size:integer, wo?:vim.wo}>
+  ---@type table<Edgy.Pos, {size:integer | fun():integer, wo?:vim.wo}>
   options = {
     left = { size = 30 },
     bottom = { size = 10 },
@@ -184,7 +184,7 @@ vim.opt.splitkeep = "screen"
 | **ft**       | `string`                       | File type of the view                                                                                       |
 | **filter**   | `fun(buf:buffer, win:window)?` | Optional function to filter buffers and windows                                                             |
 | **title**    | `string?`                      | Optional title of the view. Defaults to the capitalized filetype                                            |
-| **size**     | `number`                       | Size of the short edge of the edgebar. For edgebars, this is the minimum width. For panels, minimum height. |
+| **size**     | `number` or `fun():number`     | Size of the short edge of the edgebar. For edgebars, this is the minimum width. For panels, minimum height. |
 | **pinned**   | `boolean?`                     | If true, the view will always be shown in the edgebar even when it has no windows                           |
 | **open**     | `fun()` or `string`            | Function or command to open a pinned view                                                                   |
 | **wo**       | `vim.wo?`                      | View-specific window options                                                                                |

--- a/lua/edgy/edgebar.lua
+++ b/lua/edgy/edgebar.lua
@@ -32,9 +32,12 @@ M.__index = M
 ---@field width? number
 ---@field height? number
 
----@param size number
+---@param size number | fun(): number
 ---@param max number
 function M.size(size, max)
+  if type(size) == "function" then
+    size = size()
+  end
   return math.max(size < 1 and math.floor(max * size) or size, 1)
 end
 

--- a/lua/edgy/window.lua
+++ b/lua/edgy/window.lua
@@ -185,6 +185,9 @@ function M:apply_size()
   for _, key in ipairs({ "width", "height" }) do
     local current = vim.api["nvim_win_get_" .. key](self.win)
     local needed = self[key]
+    if type(needed) == "function" then
+      needed = needed()
+    end
     if current ~= needed then
       changes[key] = { current, needed }
       vim.api["nvim_win_set_" .. key](self.win, needed)


### PR DESCRIPTION
I wanted to equalize the height of my DAP UI left sidebar window. The best way I could do this before was using an autocmd and modifying the config table, which seemed a bit hacky, so I added the ability to set edgebar / window sizes to functions that are called to compute the suggested size.