### PR TITLE
fix: use eval_statusline to determine title width

### DIFF
--- a/lua/edgy/edgebar.lua
+++ b/lua/edgy/edgebar.lua
@@ -252,7 +252,13 @@ function M:resize()
       auto[#auto + 1] = win
     -- hidden windows
     else
-      win[long] = self.vertical and 1 or (vim.fn.strdisplaywidth(win.view.title) + 3)
+      win[long] = self.vertical and 1
+        or (
+          vim.api.nvim_eval_statusline(win.view.title, {
+            use_winbar = true,
+            winid = win.win,
+          }).width + 3
+        )
     end
     free = free - win[long]
   end

--- a/lua/edgy/edgebar.lua
+++ b/lua/edgy/edgebar.lua
@@ -251,14 +251,17 @@ function M:resize()
     elseif win.visible then
       auto[#auto + 1] = win
     -- hidden windows
+    elseif self.vertical then
+      win[long] = 1
     else
-      win[long] = self.vertical and 1
-        or (
-          vim.api.nvim_eval_statusline(win.view.title, {
-            use_winbar = true,
-            winid = win.win,
-          }).width + 3
-        )
+      local title_width = vim.fn.strdisplaywidth(win.view.title)
+      if vim.api.nvim_eval_statusline then
+        title_width = vim.api.nvim_eval_statusline(win.view.title, {
+          use_winbar = true,
+          winid = win.win,
+        }).width
+      end
+      win[long] = title_width + 3
     end
     free = free - win[long]
   end


### PR DESCRIPTION
This PR simply changes the use of `strdisplaywidth(title)` to `nvim_eval_statusline(title, {use_winbar=true}).width`. This allows the title to work properly when set to an expression resulting in a dynamically sized string.

closes #43 