### PR TITLE
feat: allow configuring whether to restore terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ vim.opt.splitkeep = "screen"
   -- close edgy when all windows are hidden instead of opening one of them
   -- disable to always keep at least one edgy split visible in each open section
   close_when_all_hidden = true,
+  -- restore terminal views when updating layout
+  restore_terms = false,
   -- global window options for edgebar windows
   ---@type vim.wo
   wo = {

--- a/lua/edgy/config.lua
+++ b/lua/edgy/config.lua
@@ -41,6 +41,8 @@ local defaults = {
   -- close edgy when all windows are hidden instead of opening one of them
   -- disable to always keep at least one edgy split visible in each open section
   close_when_all_hidden = true,
+  -- always restore terminal views to prevent flickering
+  restore_terminals = false,
   -- global window options for edgebar windows
   ---@type vim.wo
   wo = {

--- a/lua/edgy/state.lua
+++ b/lua/edgy/state.lua
@@ -1,5 +1,6 @@
 local Editor = require("edgy.editor")
 local Util = require("edgy.util")
+local Config = require("edgy.config")
 
 local M = {}
 
@@ -103,7 +104,7 @@ function M.restore()
     if wins[win] and vim.api.nvim_win_is_valid(win) then
       local buf = vim.api.nvim_win_get_buf(win)
       -- never restore terminal buffers to prevent flickering
-      if vim.bo[buf].buftype ~= "terminal" then
+      if vim.bo[buf].buftype ~= "terminal" or Config.restore_terminals then
         pcall(vim.api.nvim_win_call, win, function()
           vim.fn.winrestview(s)
         end)


### PR DESCRIPTION
Problem: Terminals are intentionally not restored to avoid flickering, but in some configs that can *cause* flickering.
Solution: Make this behavior optional, but enabled by default.