### PR TITLE
fix: High CPU Usage with Invalid Config

### DIFF
--- a/lua/edgy/util.lua
+++ b/lua/edgy/util.lua
@@ -45,10 +45,9 @@ function M.with_retry(fn, max_retries)
   local retries = 0
   local function try()
     local ok, ret = pcall(fn)
-    if ok then
-      retries = 0
-    else
-      if retries >= max_retries or require("edgy.config").debug then
+    if not ok then
+      retries = retries + 1
+      if retries >= max_retries then
         M.error(ret)
       end
       if retries < max_retries then


### PR DESCRIPTION
Hello @folke,

I've created a pull request to fix a bug where Neovim chews up 100% of a CPU core when it encounters an invalid configuration. 

The bug seems to be in `edgy.util.with_retry`, where it doesn't increase the `retries` variable, causing endless loops of retries and high CPU usage.

I've committed a fix. This should properly deal with invalid configurations and prevent Neovim from overloading the CPU.

Hope this helps out. Happy to chat more if needed!


Cheers,
Daniil