### PR TITLE
fix: use %{%} expr to get window for winbar eval

### DIFF
--- a/lua/edgy/window.lua
+++ b/lua/edgy/window.lua
@@ -30,7 +30,7 @@ function M.new(win, view)
     if vim.api.nvim_win_get_height(win) == 1 then
       vim.api.nvim_win_set_height(win, 2)
     end
-    wo.winbar = "%!v:lua.edgy_winbar(" .. win .. ")"
+    wo.winbar = "%{%v:lua.edgy_winbar()%}"
   elseif wo.winbar == false then
     wo.winbar = nil
   end
@@ -197,7 +197,8 @@ function M:apply_size()
 end
 
 ---@diagnostic disable-next-line: global_usage
-function _G.edgy_winbar(win)
+function _G.edgy_winbar()
+  local win = vim.api.nvim_get_current_win()
   local window = M.cache[win]
   return window and window:winbar() or ""
 end


### PR DESCRIPTION
Solution to what #47 attempted. When using `%{%}` nvim temporarily sets the current window so we can make use of the api to ensure we're always getting the correct window instead of relying on a number passed in on creation.

This partially solves the dynamic title issue as well because people can just incorporate %!v:lua.edgy_winbar() into their own winbars without worrying about what window is being evaluated. It doesn't deal with the width issue though.