### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ in your layout.
       {
         ft = "Outline",
         pinned = true,
-        open = "SymbolsOutlineOpen",
+        open = "OutlineOpen",
       },
       -- any other neo-tree windows
       "neo-tree",


### PR DESCRIPTION
The [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim) has been deprecated. 

The command `SymbolsOutlineOpen` is called `OutlineOpen` in the [successor plugin](https://github.com/hedyhli/outline.nvim).