### PR TITLE
feat(actions): add null check for current window in setup function

### DIFF
--- a/lua/edgy/actions.lua
+++ b/lua/edgy/actions.lua
@@ -15,7 +15,10 @@ function M.setup(win)
       -- dont override existing mappings
       if ret.buffer ~= 1 then
         vim.keymap.set("n", key, function()
-          action(require("edgy.editor").get_win())
+          local current_win = require("edgy.editor").get_win()
+          if current_win ~= nil then
+            action(current_win)
+          end
         end, { buffer = buf, silent = true })
       end
     end


### PR DESCRIPTION
This commit adds a null check for the current window in the setup function of the actions module. This ensures that the action is only performed if a valid window exists, improving the robustness of the code.