### PR TITLE
feat(view): add collapsed on start option to pinned views

### DIFF
--- a/lua/edgy/view.lua
+++ b/lua/edgy/view.lua
@@ -10,6 +10,9 @@ local Util = require("edgy.util")
 -- When a view is pinned, it will always be shown
 -- in the edgebar, even if it has no windows.
 ---@field pinned? boolean
+---When a view is pinned and collapsed, it will be
+---shown closed on start.
+---@field collapsed? boolean
 -- Open function or command to open a pinned view
 ---@field open? fun()|string
 ---@field wo? vim.wo View specific window options

--- a/lua/edgy/window.lua
+++ b/lua/edgy/window.lua
@@ -18,7 +18,7 @@ M.cache = setmetatable({}, { __mode = "v" })
 ---@param view Edgy.View
 function M.new(win, view)
   local self = setmetatable({}, M)
-  self.visible = true
+  self.visible = not view.collapsed
   self.view = view
   self.idx = 1
   self.win = win
@@ -111,7 +111,7 @@ end
 
 ---@param visibility? boolean
 function M:show(visibility)
-  self.visible = visibility == nil and true or visibility or false
+  self.visible = (visibility == nil and not self.view.collapsed) or visibility or false
   if self.visible and self:is_pinned() then
     -- self.visible = false
     return self.view:open_pinned()


### PR DESCRIPTION
Add collapsed option to view for starting up pinned views in closed mode.

## What is this PR for?
This provides option to set pinned views(not needed immediately) as collapsed on start. This helps tidying startup view of panes with multiple views.

## Does this PR fix an existing issue?
No. Purely aesthetic/visual.
