### PR TITLE
feat(commands): add on_open callbacks and restore focus on last window

### DIFF
--- a/lua/edgy/edgebar.lua
+++ b/lua/edgy/edgebar.lua
@@ -308,11 +308,26 @@ function M:resize()
   end
 end
 
-function M:open()
+---@param opts? {on_open: fun()}
+function M:open(opts)
+  local view_count = 0
+  local wait_for_views = false
+
   for _, view in ipairs(self.views) do
     if view.pinned and (#view.wins == 0 or view.wins[1]:is_pinned()) then
-      view:open_pinned()
+      view_count = view_count + 1
+      wait_for_views = true
+      view:open_pinned({on_open = function()
+        view_count = view_count - 1
+        if view_count == 0 and opts and opts.on_open then
+          opts.on_open()
+        end
+      end})
     end
+  end
+
+  if not wait_for_views and opts and opts.on_open then
+    opts.on_open()
   end
 end
 

--- a/lua/edgy/view.lua
+++ b/lua/edgy/view.lua
@@ -124,7 +124,10 @@ function M:hide_pinned(opts)
   end
 end
 
-function M:open_pinned()
+---@param opts? {on_open: fun()}
+function M:open_pinned(opts)
+  opts = opts or {}
+
   self.opening = true
   vim.schedule(function()
     Editor:goto_main()
@@ -136,6 +139,10 @@ function M:open_pinned()
       end)
     else
       Util.error("View is pinned and has no open function")
+    end
+
+    if opts.on_open then
+      opts.on_open()
     end
   end)
 end


### PR DESCRIPTION
## What is this PR for?

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

- Allow `open`/`toggle` to open without focus (restoring focus to the last window
- Add `on_open` callbacks to edgebars and views

This is what I have in my config right now:

```lua
require("edgy").toggle({ focus = false, on_open = function()
    vim.cmd("wincmd =")
end })
```

## Does this PR fix an existing issue?

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/folke/edgy.nvim/discussions/71

