### PR TITLE
fix(collapsed): make window visible for focus action

### DIFF
--- a/lua/edgy/window.lua
+++ b/lua/edgy/window.lua
@@ -165,6 +165,9 @@ function M:sibling(dir, opts)
 end
 
 function M:focus()
+  if not self.visible then
+    self:show(true)
+  end
   vim.api.nvim_set_current_win(self.win)
 end
 


### PR DESCRIPTION
## Description

Make window visible if hidden because of collapsed option is set before `focus` action.
This is expected behavior for `focus` action.

## Fixes
This makes `focus` action behavior to be consistent across collapsed and non collapsed windows.

## Related Issue(s)
None

## Screenshots



