### PR TITLE
fix(get_win): typing of the `get_win()` fn `win` param

### DIFF
--- a/lua/edgy/editor.lua
+++ b/lua/edgy/editor.lua
@@ -162,7 +162,7 @@ function M.is_floating(win)
   return vim.api.nvim_win_get_config(win).relative ~= ""
 end
 
----@param win? window
+---@param win integer? A window ID
 function M.get_win(win)
   win = win or vim.api.nvim_get_current_win()
   for _, edgebar in pairs(Config.layout) do


### PR DESCRIPTION
## Description

`vim.api.nvim_get_current_win()` and `vim.api.nvim_list_wins()` return `integer` and `integer[]`, respectively. Integer seems to be the correct typing annotation here. Similarly, `edgebar.wins.win` is a window ID integer, so the final conditional of this function is comparing the `win` param to an integer.

## Related Issue(s)

n/a

## Screenshots

<img width="994" alt="image" src="https://github.com/user-attachments/assets/3d4c2e51-b3e3-442a-ac6f-8022573f3829">

