### PR TITLE
fix(exit_when_last): 'exit_when_last' not working due to autocmd timing issue

### DIFF
--- a/lua/edgy/editor.lua
+++ b/lua/edgy/editor.lua
@@ -20,7 +20,9 @@ function M.setup()
   vim.api.nvim_create_autocmd("WinClosed", {
     group = group,
     nested = true,
-    callback = M.check_main,
+    callback = function()
+      vim.schedule(M.check_main)
+    end,
   })
 
   for _, win in ipairs(vim.api.nvim_list_wins()) do


### PR DESCRIPTION
When the `exit_when_last` option is set to `true`, closing the last main window should automatically trigger `:qa` to quit Neovim.

However, this feature is not currently working as expected. When the last main window is closed, Neovim does not exit; instead, the edgy sidebar windows remain.

The `WinClosed` event fires *during* the window closing process, not *after* the window has been completely removed from the window list.

Therefore, when `check_main()` callback executes, the window being closed **still technically exists** in Neovim's window list. This causes `vim.tbl_isempty(wins.main)` to return `false`, and the `:qa` exit logic is skipped.

Wrapping the check_main function call in vim.schedule() defers its execution to the 'next tick' of the Neovim event loop, by which point the WinClosed event has fully completed and the window has been removed from the list.
